### PR TITLE
Update find-cmake.sh to find Homebrew ARM cmake

### DIFF
--- a/3rdparty/find-cmake.sh
+++ b/3rdparty/find-cmake.sh
@@ -6,6 +6,7 @@ if which -s cmake; then
 fi
 
 known_cmake_paths="/usr/local/bin/cmake \
+  /opt/homebrew/bin/cmake \
   /opt/local/bin/cmake \
   /Applications/CMake.app/Contents/bin/cmake"
   


### PR DESCRIPTION
On ARM Macs, cmake is installed to `/opt/homebrew/bin` by Homebrew, rather than `/usr/local/bin`.

This updates the cmake finder script to search that path in addition to the existing list.