### PR TITLE
Add iOS/tvOS destinations

### DIFF
--- a/OpenEmuShaders.xcodeproj/project.pbxproj
+++ b/OpenEmuShaders.xcodeproj/project.pbxproj
@@ -941,6 +941,7 @@
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = OpenEmuShaders/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -952,8 +953,13 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3";
+				TVOS_DEPLOYMENT_TARGET = 14.0;
 			};
 			name = Debug;
 		};
@@ -972,6 +978,7 @@
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = OpenEmuShaders/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -983,7 +990,12 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3";
+				TVOS_DEPLOYMENT_TARGET = 14.0;
 			};
 			name = Release;
 		};

--- a/Source/FilterChain.swift
+++ b/Source/FilterChain.swift
@@ -262,7 +262,11 @@ final public class FilterChain {
                 }
                 
                 label = "clamp_to_border"
-                sd.sAddressMode = .clampToBorderColor
+                if #available(macOS 10.9, iOS 14.0, tvOS 16.0, *) {
+                    sd.sAddressMode = .clampToBorderColor
+                } else {
+                    // Fallback on earlier versions
+                }
                 
             case .edge:
                 label = "clamp_to_edge"
@@ -1105,7 +1109,7 @@ extension MTLLanguageVersion {
     init(_ languageVersion: Compiled.LanguageVersion) throws {
         switch languageVersion {
         case .version2_4:
-            if #available(macOS 12.0, iOS 15.0, *) {
+            if #available(macOS 12.0, iOS 15.0, tvOS 15.0, *) {
                 self = .version2_4
             } else {
                 throw MTLLangageVersionError.versionUnavailable

--- a/Source/FilterChain.swift
+++ b/Source/FilterChain.swift
@@ -159,6 +159,7 @@ final public class FilterChain {
             T1, T0, T1, T0, T1, T0, T1, T0,
         ]
         
+        #if canImport(AppKit)
         let ctx = CGContext(data: &checkerboard,
                             width: 8,
                             height: 8,
@@ -166,6 +167,15 @@ final public class FilterChain {
                             bytesPerRow: 32,
                             space: NSColorSpace.deviceRGB.cgColorSpace!,
                             bitmapInfo: CGBitmapInfo.byteOrder32Little.rawValue | CGImageAlphaInfo.premultipliedLast.rawValue)!
+        #else
+        let ctx = CGContext(data: &checkerboard,
+                            width: 8,
+                            height: 8,
+                            bitsPerComponent: 8,
+                            bytesPerRow: 32,
+                            space: CGColorSpaceCreateDeviceRGB(),
+                            bitmapInfo: CGBitmapInfo.byteOrder32Little.rawValue | CGImageAlphaInfo.premultipliedLast.rawValue)!
+        #endif
         let img = ctx.makeImage()!
         return try! loader.newTexture(cgImage: img)
     }()
@@ -358,7 +368,11 @@ final public class FilterChain {
                              size: outRectSize)
         
         // This is going into a Nearest Neighbor, so the edges should be on pixels!
+        #if canImport(AppKit)
         return NSIntegralRectWithOptions(outRect, .alignAllEdgesNearest)
+        #else
+        return CGRectIntegral(outRect)
+        #endif
     }
     
     private func resize() {
@@ -576,9 +590,11 @@ final public class FilterChain {
                         data.advanced(by: uniform.offset).copyMemory(from: uniform.data, byteCount: uniform.size)
                     }
                     
+                    #if canImport(AppKit)
                     if !deviceHasUnifiedMemory {
                         buffer.didModifyRange(0..<buffer.length)
                     }
+                    #endif
                 }
             }
         }
@@ -878,7 +894,11 @@ final public class FilterChain {
                 
                 let size = sem.size
                 guard size > 0 else { continue }
+                #if canImport(AppKit)
                 let opts: MTLResourceOptions = deviceHasUnifiedMemory ? .storageModeShared : .storageModeManaged
+                #else
+                let opts: MTLResourceOptions = .storageModeShared
+                #endif
                 let buf = device.makeBuffer(length: size, options: opts)
                 self.pass[passNumber].buffers[j] = buf
                 


### PR DESCRIPTION
Contingent on https://github.com/stuartcarnie/SwiftSPIRV-Cross/pull/2

In the meantime, I'm pointing to my "fork" here.

https://github.com/Provenance-Emu/SwiftSPIRV-Cross/tree/provenance

Provenance is looking into leveraging this framework for additional shader support in Metal.


## Changes

1. Forked SwiftSPIRV to add ios/ipados/tvos destinations
2. Added ios/ipados/tvos destinations to this workspace.
3. Fixed (i think) code for NSRect and managedMemory on iOS that is unavailable.

3 was quick and dirty to get it to build. Not sure what the side effects may be, if any.

## Notes

I clamped the iOS/tvOS versions to 14. It would probably work on 13 but I don't need it that far back.
